### PR TITLE
Unit tests + flake8 + refactor

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -27,3 +27,7 @@ wheels/
 
 # DS Store
 .DS_Store
+
+# Testing
+.coverage
+htmlcov

--- a/.travis.yml
+++ b/.travis.yml
@@ -1,0 +1,27 @@
+language: python
+
+python:
+  - 3.6
+  - 2.7
+  - 3.5
+  - 3.4
+  - 3.3
+
+cache: pip
+
+install:
+  - pip install coverage
+
+script:
+  - coverage run --include=twitter_search_funcs.py test_twitter_search_funcs.py
+
+after_success:
+  # Report coverage and send to Codecov
+  - coverage report
+  - pip install codecov && codecov
+
+after_script:
+  - coverage report
+
+matrix:
+  fast_finish: true

--- a/.travis.yml
+++ b/.travis.yml
@@ -10,9 +10,14 @@ python:
 cache: pip
 
 install:
-  - pip install coverage
+  - pip install coverage pyflakes
 
 script:
+
+  # Static analysis
+  - pyflakes .
+
+  # Unit tests
   - coverage run --include=twitter_search_funcs.py test_twitter_search_funcs.py
 
 after_success:

--- a/test_twitter_search_funcs.py
+++ b/test_twitter_search_funcs.py
@@ -1,0 +1,101 @@
+#!/usr/bin/env python
+"""
+Unit tests for twitter_search_funcs.py
+"""
+from __future__ import print_function, unicode_literals
+
+import unittest
+from twitter_search_funcs import find_context as fc
+
+
+class TestIt(unittest.TestCase):
+
+    def test_find_context_not_found(self):
+        # Arrange
+        tweet = "has no eks character"
+        char = "x"
+
+        # Act
+        char_before, word_before, char_after, word_after = fc(tweet, char)
+
+        # Assert
+        self.assertIsNone(char_before)
+        self.assertIsNone(word_before)
+        self.assertIsNone(char_after)
+        self.assertIsNone(word_after)
+
+    def test_find_context_unit_length(self):
+        # Arrange
+        tweet = "x"
+        char = "x"
+
+        # Act
+        char_before, word_before, char_after, word_after = fc(tweet, char)
+
+        # Assert
+        self.assertIsNone(char_before)
+        self.assertIsNone(word_before)
+        self.assertIsNone(char_after)
+        self.assertIsNone(word_after)
+
+    def test_find_context_words_before_and_after(self):
+        # Arrange
+        tweet = "before x after"
+        char = "x"
+
+        # Act
+        char_before, word_before, char_after, word_after = fc(tweet, char)
+
+        # Assert
+        self.assertEqual(char_before, "e")
+        self.assertEqual(word_before, "before")
+        self.assertEqual(char_after, "a")
+        self.assertEqual(word_after, "after")
+
+    def test_find_context_at_start_of_tweet(self):
+        # Arrange
+        tweet = "x at start of tweet"
+        char = "x"
+
+        # Act
+        char_before, word_before, char_after, word_after = fc(tweet, char)
+
+        # Assert
+        self.assertIsNone(char_before)
+        self.assertIsNone(word_before)
+        self.assertEqual(char_after, "a")
+        self.assertEqual(word_after, "at")
+
+    def test_find_context_at_end_of_tweet(self):
+        # Arrange
+        tweet = "tweet ending in x"
+        char = "x"
+
+        # Act
+        char_before, word_before, char_after, word_after = fc(tweet, char)
+
+        # Assert
+        self.assertEqual(char_before, "n")
+        self.assertEqual(word_before, "in")
+        self.assertIsNone(char_after)
+        self.assertIsNone(word_after)
+
+    def test_find_context_repeated_target(self):
+        # Arrange
+        tweet = "xx"
+        char = "x"
+
+        # Act
+        char_before, word_before, char_after, word_after = fc(tweet, char)
+
+        # Assert
+        self.assertIsNone(char_before)
+        self.assertIsNone(word_before)
+        self.assertEqual(char_after, "x")
+        self.assertIsNone(word_after)
+
+
+if __name__ == '__main__':
+    unittest.main()
+
+# End of file

--- a/twitter_search_funcs.py
+++ b/twitter_search_funcs.py
@@ -6,7 +6,6 @@ Functions for searching Twitter json
 
 """
 
-import os
 import sys
 
 __author__ = "Jane Solomon and Jeremy Smith"
@@ -27,9 +26,9 @@ def progress(count, total, suffix=''):
 
 def find_context(tweet, char):
     """Finds a character (char) in tweet and its nearest neighbors
-    both character and word. Ignores spaces for the nearest character search. 
-    Leaves new line character in results to avoid associating character 
-    separated by a new line as a nearest neighbor. Only searches for 
+    both character and word. Ignores spaces for the nearest character search.
+    Leaves new line character in results to avoid associating character
+    separated by a new line as a nearest neighbor. Only searches for
     the first instance of the character."""
 
     # Tweet split into a list of words
@@ -68,6 +67,6 @@ def find_context(tweet, char):
         word_after = None
     else:
         word_before = tweet_word_list[wloc - 1]
-        word_after = tweet_word_list[wloc + 1] 
+        word_after = tweet_word_list[wloc + 1]
 
     return char_before, word_before, char_after, word_after

--- a/twitter_search_funcs.py
+++ b/twitter_search_funcs.py
@@ -40,8 +40,6 @@ def find_context(tweet, char):
     # If character is not found (i.e. loc = -1) then return None
     if loc == -1:
         return None, None, None, None
-    # Word location of char
-    wloc = next((tweet_word_list.index(w) for w in tweet_word_list if char in w), None)
 
     # Finds character before and after
     if len(tweet_clean) == 1:
@@ -55,6 +53,9 @@ def find_context(tweet, char):
     else:
         char_before = tweet_clean[loc - 1]
         char_after = tweet_clean[loc + 1]
+
+    # Word location of char
+    wloc = next((tweet_word_list.index(w) for w in tweet_word_list if char in w), None)
 
     # Finds word before and after
     if len(tweet_word_list) == 1:


### PR DESCRIPTION
* Includes PR #1.
* Fix some minor things found by running `pip install flake8` and then `flake8 .`. 
    * Include this on the CI to prevent possible future errors.
* Move the calculation of `wloc` to just before it's used, as it's possible we might return before it's even needed. 
    * This may speed things up when processing lots and lots of tweets (and it was a bit faster when running the unit tests many times).

Another possible refactor would be to move:
```python
    # Finds character before and after
    if len(tweet_clean) == 1:
        return None, None, None, None
```
to before the calculation of `loc`. This wasn't actually faster when running unit tests many times. They're a bit artificial, so it could be faster with real tweet data, but I'd guess not.