### PR TITLE
Speed up x2.7 using multiprocessing

### DIFF
--- a/full_search.py
+++ b/full_search.py
@@ -1,0 +1,106 @@
+import os
+import sys
+import json
+import bz2
+import seaborn
+import pandas as pd
+from unicode_codes import EMOJI_UNICODE
+from twitter_search_funcs import *
+from timeit import default_timer as timer
+
+data_path = "/your/data/path/archive-twitter-2016-08/"
+
+# Character to match
+match = EMOJI_UNICODE[':pistol:']
+
+# Counters
+counter_total_tweets = 0
+counter_total_match = 0
+counter_total_before = 0
+counter_total_after = 0
+counterdict_before = {}
+counterdict_after = {}
+counterdict_lang = {}
+
+# Main search loop
+start_t = timer()
+for day in range(31):
+    day_str = "{:02d}".format(day + 1)
+    for hour in range(24):
+        hour_str = "{:02d}".format(hour)
+        file_path = os.path.join(data_path, day_str, hour_str)
+        files = os.listdir(file_path)
+        for i, f in enumerate(files):
+            progress(i + hour * len(files),
+                     len(files) * 24,
+                     suffix="Searching Day {}, Hour {}".format(day_str, hour_str))
+            fbz = bz2.BZ2File(os.path.join(file_path, f), 'rb')
+            try:
+                fdec = fbz.read()
+            except IOError:
+                continue
+            finally:
+                fbz.close()
+            fdecutf = fdec.decode('utf-8')
+
+            for t in fdecutf.split('\n'):
+                try:
+                    tweet = json.loads(t)
+                except (ValueError):
+                    continue
+                if 'delete' in tweet.keys():
+                    continue
+                counter_total_tweets += 1
+                if match in tweet['text']:
+                    counter_total_match += 1
+                    result = find_context(tweet['text'], match)
+
+                    if result[0] in EMOJI_UNICODE.values():
+                        counter_total_before += 1
+
+                        if result[0] in counterdict_before.keys():
+                            counterdict_before[result[0]] += 1
+                        else:
+                            counterdict_before[result[0]] = 1
+
+                    if result[2] in EMOJI_UNICODE.values():
+                        counter_total_after += 1
+
+                        if result[2] in counterdict_after.keys():
+                            counterdict_after[result[2]] += 1
+                        else:
+                            counterdict_after[result[2]] = 1
+
+                    try:
+                        if tweet['lang'] in counterdict_lang.keys():
+                            counterdict_lang[tweet['lang']] += 1
+                        else:
+                            counterdict_lang[tweet['lang']] = 1
+                    except KeyError:
+                        continue
+end_t = timer()
+
+# Print outputs
+print("Elapsed Time    : {:.2f} min".format((end_t - start_t) / 60))
+print("Total Tweets    : {:d}".format(counter_total_tweets))
+print("Total Matches   : {:d}".format(counter_total_match))
+print("Total w/ Before : {:d}".format(counter_total_before))
+print("Total w/ After  : {:d}".format(counter_total_after))
+
+# Convert output to dataframe
+df_before = pd.DataFrame(list(counterdict_before.items()), columns=['Emoji', 'CountBefore'])
+df_after = pd.DataFrame(list(counterdict_after.items()), columns=['Emoji', 'CountAfter'])
+df_lang = pd.DataFrame(list(counterdict_lang.items()), columns=['Lang', 'Count'])
+
+# Merge before and after dataframes
+df_all = pd.merge(df_before, df_after, on='Emoji', how='outer')
+
+df_all.sort_values('CountBefore', ascending=False).head()
+df_all.sort_values('CountAfter', ascending=False).head()
+df_lang.sort_values('Count', ascending=False).head()
+df_all.sort_values('CountBefore', ascending=False).head(20).plot.bar(y='CountBefore')
+df_all.sort_values('CountAfter', ascending=False).head(20).plot.bar(y='CountAfter')
+
+# Export results as CSV files
+df_all.to_csv("./alldata.csv")
+df_lang.to_csv("./langdata.csv")

--- a/full_search.py
+++ b/full_search.py
@@ -1,12 +1,12 @@
-import os
-import sys
-import json
+#!/usr/bin/env python
+# encoding: utf-8
 import bz2
-import seaborn
+import json
+import os
 import pandas as pd
-from unicode_codes import EMOJI_UNICODE
-from twitter_search_funcs import *
 from timeit import default_timer as timer
+from twitter_search_funcs import find_context, progress
+from unicode_codes import EMOJI_UNICODE
 
 data_path = "/your/data/path/archive-twitter-2016-08/"
 

--- a/full_search.py
+++ b/full_search.py
@@ -33,7 +33,8 @@ for day in range(31):
         for i, f in enumerate(files):
             progress(i + hour * len(files),
                      len(files) * 24,
-                     suffix="Searching Day {}, Hour {}".format(day_str, hour_str))
+                     suffix="Searching Day {}, Hour {}".format(day_str,
+                                                               hour_str))
             fbz = bz2.BZ2File(os.path.join(file_path, f), 'rb')
             try:
                 fdec = fbz.read()
@@ -88,9 +89,12 @@ print("Total w/ Before : {:d}".format(counter_total_before))
 print("Total w/ After  : {:d}".format(counter_total_after))
 
 # Convert output to dataframe
-df_before = pd.DataFrame(list(counterdict_before.items()), columns=['Emoji', 'CountBefore'])
-df_after = pd.DataFrame(list(counterdict_after.items()), columns=['Emoji', 'CountAfter'])
-df_lang = pd.DataFrame(list(counterdict_lang.items()), columns=['Lang', 'Count'])
+df_before = pd.DataFrame(list(counterdict_before.items()),
+                         columns=['Emoji', 'CountBefore'])
+df_after = pd.DataFrame(list(counterdict_after.items()),
+                        columns=['Emoji', 'CountAfter'])
+df_lang = pd.DataFrame(list(counterdict_lang.items()),
+                       columns=['Lang', 'Count'])
 
 # Merge before and after dataframes
 df_all = pd.merge(df_before, df_after, on='Emoji', how='outer')
@@ -98,8 +102,10 @@ df_all = pd.merge(df_before, df_after, on='Emoji', how='outer')
 df_all.sort_values('CountBefore', ascending=False).head()
 df_all.sort_values('CountAfter', ascending=False).head()
 df_lang.sort_values('Count', ascending=False).head()
-df_all.sort_values('CountBefore', ascending=False).head(20).plot.bar(y='CountBefore')
-df_all.sort_values('CountAfter', ascending=False).head(20).plot.bar(y='CountAfter')
+df_all.sort_values('CountBefore',
+                   ascending=False).head(20).plot.bar(y='CountBefore')
+df_all.sort_values('CountAfter',
+                   ascending=False).head(20).plot.bar(y='CountAfter')
 
 # Export results as CSV files
 df_all.to_csv("./alldata.csv")

--- a/full_search.py
+++ b/full_search.py
@@ -108,5 +108,5 @@ df_all.sort_values('CountAfter',
                    ascending=False).head(20).plot.bar(y='CountAfter')
 
 # Export results as CSV files
-df_all.to_csv("./alldata.csv")
-df_lang.to_csv("./langdata.csv")
+df_all.to_csv("./alldata.csv", encoding="utf-8")
+df_lang.to_csv("./langdata.csv", encoding="utf-8")

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,0 +1,2 @@
+pandas
+tqdm

--- a/twitter_search_funcs.py
+++ b/twitter_search_funcs.py
@@ -6,22 +6,8 @@ Functions for searching Twitter json
 
 """
 
-import sys
-
 __author__ = "Jane Solomon and Jeremy Smith"
 __version__ = "1.0"
-
-
-def progress(count, total, suffix=''):
-    """Progress bar function"""
-    bar_len = 60
-    filled_len = int(round(bar_len * count / float(total)))
-
-    percents = round(100.0 * count / float(total), 1)
-    bar = '=' * filled_len + '-' * (bar_len - filled_len)
-
-    sys.stdout.write('[%s] %#5.1f%s ...%s\r' % (bar, percents, '%', suffix))
-    sys.stdout.flush()
 
 
 def find_context(tweet, char):


### PR DESCRIPTION

I timed the change in PR https://github.com/janesolomon/twitter_search/pull/2 on a subset of one day's tweets, and the PR was slightly quicker (15.69 min) than the original (15.76 min), and the other suggested possible refactor was slightly slower (15.79 min), but just by a couple of minutes when scaled up to a whole month's worth (31\*15.76 - 31\*15.69 = 2.17min).

But we can do better! The original code is sequential: one file zipped file of tweets is opened, processed, results are stored, and then we move on to the next file. This doesn't make full use of the computer's often multiple CPUs.

---

Multiprocessing
---

Instead, we can use Python's `multiprocessing` library. For this, we create a new worker function and move into here the main bit of code that processes a file of zipped tweets. 

We then create a `Pool` that represents a pool of worker processes. The maximum that can run at any one time is set as the number of CPUs on the computer (`multiprocessing.cpu_count()`, 4 on this computer). We tell that to run the worker function on each of the filenames we have. It then runs each worker in its own process (up to that maximum). When one finishes, it'll take another from the pool.

```python
pool = multiprocessing.Pool(number_of_processes)
results = pool.map(worker, files)
```

Because of the way the multiprocessing works, the results can't be put in big global lists and dictionaries directly by the worker. So it pops them into its own dict and returns them. Then at the end, these are combined together. 

Also, the multiprocessing means that zip files are not necessarily processed in the same order, and the order of results in the CSVs may be a bit different, but that doesn't really matter: the totals and values are the same.

(For this, I also copied full_search_v1.ipynb into full_search.py to run it from the command line like `python full_search.py` because I'm not familiar with Jupyter Notebook. I've not deleted full_search_v1.ipynb in case there's something it was doing which is missed in the script, but in general it's better to avoid duplicating things.)

---

Results
---

Here's the CPU usage of the original sequential code (on Windows 7 with four CPUs/16 GB RAM):

![CPUs at 30%](https://user-images.githubusercontent.com/1324225/27253600-6826b860-5380-11e7-8576-5d79d08c15cf.png)

Here's how it looks with multiprocessing:

![CPUs at 100%](https://user-images.githubusercontent.com/1324225/27253715-36d0eb76-5382-11e7-9a84-c955fff6a8af.png)

Here's how long the original took (running on the full January 2017 tweet archive):
```
Elapsed Time    : 490.88 min=================================]  99.9% ...Searching Day 31, Hour 23
Total Tweets    : 112407850
Total Matches   : 22922
Total w/ Before : 482
Total w/ After  : 0
```

And with multiprocessing:
```
Elapsed Time    : 197.60 min=================================]  99.9% ...Searching Day 31, Hour 23
Total Tweets    : 112407850
Total Matches   : 22922
Total w/ Before : 482
Total w/ After  : 0
```

490.88 min -> 197.60 min == 8h 11m -> 3h 18m

That's about 2.5 times faster!

---

Other notes
---

The progress bar isn't as smooth. Before it would update with each file, now it only updates after processing each hour's worth of tweets. I expect this can be improved, but it's not a big worry.

Maybe this could be sped up a little more. I think those dips in the CPU chart are when it's finished one hour and moving onto the next, which involves the pool emptying completely before we fill it up with the next hours. Perhaps it'd be a bit faster if we made one big `files` list for all days and hours, and then fed that into the pool. I might test this out.
