### PR TITLE
Add command-line options with argparse

### DIFF
--- a/full_search.py
+++ b/full_search.py
@@ -1,3 +1,10 @@
+#!/usr/bin/env python
+# encoding: utf-8
+"""
+Search a Twitter archive (from archive.org) to find the characters which
+occur before and after a chosen target.
+"""
+import argparse
 import bz2
 import json
 import multiprocessing
@@ -8,8 +15,6 @@ from unicode_codes import EMOJI_UNICODE
 from timeit import default_timer as timer
 from tqdm import tqdm  # pip install tqdm
 from twitter_search_funcs import find_context
-
-data_path = "/your/data/path/archive-twitter-2016-08/"
 
 # Character to match
 match = EMOJI_UNICODE[':pistol:']
@@ -97,6 +102,16 @@ def worker(filename):
 
 
 if __name__ == "__main__":
+    parser = argparse.ArgumentParser(
+        description="Search a Twitter archive (from archive.org) to find the "
+                    "characters which occur before and after a chosen target",
+        formatter_class=argparse.ArgumentDefaultsHelpFormatter)
+    parser.add_argument(
+        '-p', '--data_path',
+        default="/your/data/path/archive-twitter-2016-08/",
+        help="Path to the Twitter archive")
+    args = parser.parse_args()
+
     number_of_processes = multiprocessing.cpu_count()
     multiprocessing.freeze_support()  # Prevent an error on Windows
 
@@ -107,7 +122,7 @@ if __name__ == "__main__":
         day_str = "{:02d}".format(day + 1)
         for hour in range(24):
             hour_str = "{:02d}".format(hour)
-            file_path = os.path.join(data_path, day_str, hour_str)
+            file_path = os.path.join(args.data_path, day_str, hour_str)
             files = os.listdir(file_path)
 
             for i, f in enumerate(files):

--- a/full_search.py
+++ b/full_search.py
@@ -1,0 +1,106 @@
+import os
+import sys
+import json
+import bz2
+import seaborn
+import pandas as pd
+from unicode_codes import EMOJI_UNICODE
+from twitter_search_funcs import *
+from timeit import default_timer as timer
+
+data_path = "/your/data/path/archive-twitter-2016-08/"
+
+# Character to match
+match = EMOJI_UNICODE[':pistol:']
+
+# Counters
+counter_total_tweets = 0
+counter_total_match = 0
+counter_total_before = 0
+counter_total_after = 0
+counterdict_before = {}
+counterdict_after = {}
+counterdict_lang = {}
+
+# Main search loop
+start_t = timer()
+for day in range(31):
+    day_str = "{:02d}".format(day + 1)
+    for hour in range(24):
+        hour_str = "{:02d}".format(hour)
+        file_path = os.path.join(data_path, day_str, hour_str)
+        files = os.listdir(file_path)
+        for i, f in enumerate(files):
+            progress(i + hour * len(files),
+                     len(files) * 24,
+                     suffix="Searching Day {}, Hour {}".format(day_str, hour_str))
+            fbz = bz2.BZ2File(os.path.join(file_path, f), 'rb')
+            try:
+                fdec = fbz.read()
+            except IOError:
+                continue
+            finally:
+                fbz.close()
+            fdecutf = fdec.decode('utf-8')
+
+            for t in fdecutf.split('\n'):
+                try:
+                    tweet = json.loads(t)
+                except (ValueError):
+                    continue
+                if 'delete' in tweet.keys():
+                    continue
+                counter_total_tweets += 1
+                if match in tweet['text']:
+                    counter_total_match += 1
+                    result = find_context(tweet['text'], match)
+
+                    if result[0] in EMOJI_UNICODE.values():
+                        counter_total_before += 1
+
+                        if result[0] in counterdict_before.keys():
+                            counterdict_before[result[0]] += 1
+                        else:
+                            counterdict_before[result[0]] = 1
+
+                    if result[2] in EMOJI_UNICODE.values():
+                        counter_total_after += 1
+
+                        if result[2] in counterdict_after.keys():
+                            counterdict_after[result[2]] += 1
+                        else:
+                            counterdict_after[result[2]] = 1
+
+                    try:
+                        if tweet['lang'] in counterdict_lang.keys():
+                            counterdict_lang[tweet['lang']] += 1
+                        else:
+                            counterdict_lang[tweet['lang']] = 1
+                    except KeyError:
+                        continue
+end_t = timer()
+
+# Print outputs
+print("Elapsed Time    : {:.2f} min".format((end_t - start_t) / 60))
+print("Total Tweets    : {:d}".format(counter_total_tweets))
+print("Total Matches   : {:d}".format(counter_total_match))
+print("Total w/ Before : {:d}".format(counter_total_before))
+print("Total w/ After  : {:d}".format(counter_total_after))
+
+# Convert output to dataframe
+df_before = pd.DataFrame(list(counterdict_before.items()), columns=['Emoji', 'CountBefore'])
+df_after = pd.DataFrame(list(counterdict_after.items()), columns=['Emoji', 'CountAfter'])
+df_lang = pd.DataFrame(list(counterdict_lang.items()), columns=['Lang', 'Count'])
+
+# Merge before and after dataframes
+df_all = pd.merge(df_before, df_after, on='Emoji', how='outer')
+
+df_all.sort_values('CountBefore', ascending=False).head()
+df_all.sort_values('CountAfter', ascending=False).head()
+df_lang.sort_values('Count', ascending=False).head()
+df_all.sort_values('CountBefore', ascending=False).head(20).plot.bar(y='CountBefore')
+df_all.sort_values('CountAfter', ascending=False).head(20).plot.bar(y='CountAfter')
+
+# Export results as CSV files
+df_all.to_csv("./alldata.csv")
+df_lang.to_csv("./langdata.csv")

--- a/full_search.py
+++ b/full_search.py
@@ -1,12 +1,12 @@
-import os
-import sys
-import json
+#!/usr/bin/env python
+# encoding: utf-8
 import bz2
-import seaborn
+import json
+import os
 import pandas as pd
-from unicode_codes import EMOJI_UNICODE
-from twitter_search_funcs import *
 from timeit import default_timer as timer
+from twitter_search_funcs import find_context, progress
+from unicode_codes import EMOJI_UNICODE
 
 data_path = "/your/data/path/archive-twitter-2016-08/"
 

--- a/full_search.py
+++ b/full_search.py
@@ -33,7 +33,8 @@ for day in range(31):
         for i, f in enumerate(files):
             progress(i + hour * len(files),
                      len(files) * 24,
-                     suffix="Searching Day {}, Hour {}".format(day_str, hour_str))
+                     suffix="Searching Day {}, Hour {}".format(day_str,
+                                                               hour_str))
             fbz = bz2.BZ2File(os.path.join(file_path, f), 'rb')
             try:
                 fdec = fbz.read()
@@ -88,9 +89,12 @@ print("Total w/ Before : {:d}".format(counter_total_before))
 print("Total w/ After  : {:d}".format(counter_total_after))
 
 # Convert output to dataframe
-df_before = pd.DataFrame(list(counterdict_before.items()), columns=['Emoji', 'CountBefore'])
-df_after = pd.DataFrame(list(counterdict_after.items()), columns=['Emoji', 'CountAfter'])
-df_lang = pd.DataFrame(list(counterdict_lang.items()), columns=['Lang', 'Count'])
+df_before = pd.DataFrame(list(counterdict_before.items()),
+                         columns=['Emoji', 'CountBefore'])
+df_after = pd.DataFrame(list(counterdict_after.items()),
+                        columns=['Emoji', 'CountAfter'])
+df_lang = pd.DataFrame(list(counterdict_lang.items()),
+                       columns=['Lang', 'Count'])
 
 # Merge before and after dataframes
 df_all = pd.merge(df_before, df_after, on='Emoji', how='outer')
@@ -98,8 +102,10 @@ df_all = pd.merge(df_before, df_after, on='Emoji', how='outer')
 df_all.sort_values('CountBefore', ascending=False).head()
 df_all.sort_values('CountAfter', ascending=False).head()
 df_lang.sort_values('Count', ascending=False).head()
-df_all.sort_values('CountBefore', ascending=False).head(20).plot.bar(y='CountBefore')
-df_all.sort_values('CountAfter', ascending=False).head(20).plot.bar(y='CountAfter')
+df_all.sort_values('CountBefore',
+                   ascending=False).head(20).plot.bar(y='CountBefore')
+df_all.sort_values('CountAfter',
+                   ascending=False).head(20).plot.bar(y='CountAfter')
 
 # Export results as CSV files
 df_all.to_csv("./alldata.csv")

--- a/full_search.py
+++ b/full_search.py
@@ -110,6 +110,12 @@ if __name__ == "__main__":
         '-p', '--data_path',
         default="/your/data/path/archive-twitter-2016-08/",
         help="Path to the Twitter archive")
+    parser.add_argument(
+        '-d', '--days', type=int, default=31,
+        help="How many days to search (for testing)")
+    parser.add_argument(
+        '-hr', '--hours', type=int, default=24,
+        help="How many hours to search (for testing)")
     args = parser.parse_args()
 
     number_of_processes = multiprocessing.cpu_count()
@@ -118,9 +124,9 @@ if __name__ == "__main__":
     # Main search loop
     start_t = timer()
     all_files = []
-    for day in range(31):
+    for day in range(args.days):
         day_str = "{:02d}".format(day + 1)
-        for hour in range(24):
+        for hour in range(args.hours):
             hour_str = "{:02d}".format(hour)
             file_path = os.path.join(args.data_path, day_str, hour_str)
             files = os.listdir(file_path)

--- a/full_search.py
+++ b/full_search.py
@@ -108,5 +108,5 @@ df_all.sort_values('CountAfter',
                    ascending=False).head(20).plot.bar(y='CountAfter')
 
 # Export results as CSV files
-df_all.to_csv("./alldata.csv")
-df_lang.to_csv("./langdata.csv")
+df_all.to_csv("./alldata.csv", encoding="utf-8")
+df_lang.to_csv("./langdata.csv", encoding="utf-8")

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,0 +1,2 @@
+pandas
+tqdm

--- a/twitter_search_funcs.py
+++ b/twitter_search_funcs.py
@@ -6,22 +6,8 @@ Functions for searching Twitter json
 
 """
 
-import sys
-
 __author__ = "Jane Solomon and Jeremy Smith"
 __version__ = "1.0"
-
-
-def progress(count, total, suffix=''):
-    """Progress bar function"""
-    bar_len = 60
-    filled_len = int(round(bar_len * count / float(total)))
-
-    percents = round(100.0 * count / float(total), 1)
-    bar = '=' * filled_len + '-' * (bar_len - filled_len)
-
-    sys.stdout.write('[%s] %#5.1f%s ...%s\r' % (bar, percents, '%', suffix))
-    sys.stdout.flush()
 
 
 def find_context(tweet, char):


### PR DESCRIPTION
This includes #3, you can see the new changes in this diff: https://github.com/hugovk/twitter_search/compare/multiprocessing...hugovk:argparse?expand=1

```bash
$ python3 full_search.py --help
usage: full_search.py [-h] [-p DATA_PATH] [-d DAYS] [-hr HOURS]

Search a Twitter archive (from archive.org) to find the characters which occur
before and after a chosen target

optional arguments:
  -h, --help            show this help message and exit
  -p DATA_PATH, --data_path DATA_PATH
                        Path to the Twitter archive (default:
                        /your/data/path/archive-twitter-2016-08/)
  -d DAYS, --days DAYS  How many days to search (for testing) (default: 31)
  -hr HOURS, --hours HOURS
                        How many hours to search (for testing) (default: 24)
```

So you can specify the data path using `--data_path` or `-p`, useful for running on different Twitter archives. 

And you can tell it how many days or hours to use, handy for getting quick results, for example when testing multiprocessing gives the same results as non-multiprocessing :)
