### PR TITLE
Remove unsupported Python 3.3

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -5,7 +5,6 @@ python:
   - 2.7
   - 3.5
   - 3.4
-  - 3.3
 
 cache: pip
 


### PR DESCRIPTION
It has reached end-of-life: https://en.wikipedia.org/wiki/CPython#Version_history